### PR TITLE
Fix README tables

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,17 +34,19 @@ If you wish to run local instancie of NCI reefer to this guide!
 All of the configuration is handled via environmental variables.
 
 #### Frontend Options
-Option | Type | Description
-- | - | -
-`NCI_BACKEND_IP`  | Optional | This variable specify where frontend should connect to fetch images. It defaults to `localhost:NCI_BACKEND_PORT` or if it is not set, to `localhost:8000`
+
+| Option | Type | Description |
+| - | - | - |
+| `NCI_BACKEND_IP`  | Optional | This variable specify where frontend should connect to fetch images. It defaults to `localhost:NCI_BACKEND_PORT` or if it is not set, to `localhost:8000` |
 
 #### Backend Options
-Option | Type | Description
-- | - | -
-`NCI_BACKEND_PORT` | Optional | This variable specify application port to run backend server, if not set it defaults to `8000`
-`NCI_PIXABAY_KEY` | Optional | Pixabay [API key](https://pixabay.com/api/docs/)
-`NCI_PEXELS_KEY` | Optional | Pexels [API key](https://www.pexels.com/api/new/)
-`NCI_UNSPLASH_KEY` | Optional | Unsplash [API key](https://unsplash.com/oauth/applications)
+
+| Option | Type | Description |
+| - | - | - |
+| `NCI_BACKEND_PORT` | Optional | This variable specify application port to run backend server, if not set it defaults to `8000` |
+| `NCI_PIXABAY_KEY` | Optional | Pixabay [API key](https://pixabay.com/api/docs/) |
+| `NCI_PEXELS_KEY` | Optional | Pexels [API key](https://www.pexels.com/api/new/) |
+| `NCI_UNSPLASH_KEY` | Optional | Unsplash [API key](https://unsplash.com/oauth/applications) |
 
 
 ### 2. Running client side


### PR DESCRIPTION
Apparently, GitHub parses tables a little bit differently than vscode. That should fix them
![image](https://user-images.githubusercontent.com/23432278/95177621-b530ff80-07be-11eb-956a-7aa6fa138da6.png)
